### PR TITLE
K8

### DIFF
--- a/Dockerfile.k8
+++ b/Dockerfile.k8
@@ -1,0 +1,23 @@
+FROM nginx:1.21
+COPY dist /dist
+ADD docker/start-k8.sh /
+RUN chmod a+rx /start-k8.sh
+
+## Clean out defualt nginx files from html folder
+RUN rm -f /usr/share/nginx/html/*
+
+## Temp
+ENV BASE_URL "http://localhost"
+ENV COMPONENT_URL "http://localhost/cta"
+ENV PERSISTENCE_URL "http://localhost/ps"
+ENV MDQ_URL "http://localhost:8000/entities"
+ENV SEARCH_URL "http://localhost:8000/api/search"
+ENV MDQ_HOSTPORT "localhost:8000"
+ENV STORAGE_DOMAIN "localhost"
+ENV LOGLEVEL "warn"
+ENV DEFAULT_CONTEXT "local"
+
+## Use the custom start script, which will replace envvars and copy dist into nginx html folder
+ENTRYPOINT ["/start-k8.sh"]
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,12 @@ publish:
 
 build_in_docker: thiss_builder
 	docker run -ti -v $(PWD)/dist:/usr/src/app/dist -e BASE_URL=$(BASE_URL) -e COMPONENT_URL=$(COMPONENT_URL) -e MDQ_URL=$(MDQ_URL) -e PERSISTENCE_URL=$(PERSISTENCE_URL) -e SEARCH_URL=$(SEARCH_URL) -e STORAGE_DOMAIN=$(STORAGE_DOMAIN) -e LOGLEVEL=$(LOGLEVEL) -e DEFAULT_CONTEXT=$(DEFAULT_CONTEXT) -e WHITELIST=${WHITELIST} thiss-builder:$(VERSION) webpack --config webpack.prod.js
-	
+
 build: test snyk
 	env BASE_URL=$(BASE_URL) COMPONENT_URL=$(COMPONENT_URL) MDQ_URL=$(MDQ_URL) PERSISTENCE_URL=$(PERSISTENCE_URL) SEARCH_URL=$(SEARCH_URL) STORAGE_DOMAIN=$(STORAGE_DOMAIN) LOGLEVEL=$(LOGLEVEL) DEFAULT_CONTEXT=$(DEFAULT_CONTEXT) WHITELIST=${WHITELIST} webpack --config webpack.prod.js
+
+build-prod: test snyk
+	webpack --config webpack.prod.js
 
 standalone: standalone_in_docker
 

--- a/docker/start-k8.sh
+++ b/docker/start-k8.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+echo "Start of start-ks.sh"
+
+echo "Copy and parsing of files starting"
+
+cd /dist
+for f in `find . -printf '%P\n'`; do
+   if [ "x$f" != "x" -a -f $f ]; then
+      d=`dirname $f`
+      mkdir -p /usr/share/nginx/html/$d
+      envsubst '${BASE_URL} ${STORAGE_DOMAIN} ${MDQ_URL} ${SEARCH_URL} ${DEFAULT_CONTEXT} ${LOGLEVEL} ${WHITELIST}' < $f > /usr/share/nginx/html/$f
+   fi
+done
+
+echo "Copy and parsing of files complete"
+
+echo "Launching standard nginx entrypoint"
+
+source /docker-entrypoint.sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@theidentityselector/thiss",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/assets/translations/sv.json
+++ b/src/assets/translations/sv.json
@@ -1,0 +1,33 @@
+{
+  "@metadata": {
+    "authors": [
+      "Fredrik Domeij"
+    ],
+    "last-updated": "2021-11-18",
+    "locale": "sv"
+  },
+  "cta-button-placeholder": "Inloggning via din organisation",
+  "cta-button-header": "Inloggning via",
+  "cta-link": "Lägg till eller ändra organisation",
+  "ds-header": "Inloggning till",
+  "ds-footer-about-us": "Om oss",
+  "ds-search-heading": "Hitta Din Organisation",
+  "ds-search-subheading": "Ditt lärosäte, organisation eller företag",
+  "ds-search-example": "Exempel: Umeå universitet, eduID Sweden",
+  "ds-search-placeholder": "Söker efter organisationer...",
+  "ds-choose-heading": "Välj Din Organisation",
+  "ds-choose-subheading": "Nyligen använda",
+  "ds-choose-add-another": "Välj en annan organisation",
+  "ds-edit-heading": "Ändra organisationer",
+  "ds-edit-subheading": "Om du inte längre vill att en organisation ska listas på denna enhet, ta bort den från listan nedan.",
+  "ds-choose-edit": "Ändra",
+  "ds-choose-done": "Klar",
+  "ds-notice-and-consent-remember": "Kom ihåg mitt val",
+  "ds-notice-and-consent-learn-more": "Mer information",
+  "ds-notice-and-consent-banner-storage-info": "Organisationen du väljer kommer att sparas i denna enhets lokala lagring och kommer att vara tillgänglig för denna och andra tjänster som använder SeamlessAccess. Du kan rensa den lokala lagringen i din enhet när du vill.",
+  "ds-notice-and-consent-banner-more-info": "Hantering av personuppgifter i SeamlessAccess",
+  "ds-notice-and-consent-banner-personal-info": "Inga personuppgifter sparas.",
+  "ds-too-many-result-show": "Visa alla träffar",
+  "ds-too-many-result-matches": "träffar",
+  "ds-too-many-result-keep-typing": "fortsätt skriva för att begränsa sökresultatet"
+}

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -26,9 +26,9 @@ module.exports = merge(common, {
        new webpack.EnvironmentPlugin({
        BASE_URL: 'http://localhost:9000/',
        COMPONENT_URL: 'http://localhost:9000/cta/',
-       MDQ_URL: '/entities/',
+       MDQ_URL: 'http://localhost:3000/entities/',
        PERSISTENCE_URL: 'http://localhost:9000/ps/',
-       SEARCH_URL: '/entities/',
+       SEARCH_URL: 'http://localhost:3000/entities/',
        STORAGE_DOMAIN: 'localhost:9000',
        LOGLEVEL: 'warn',
        DEFAULT_CONTEXT: 'thiss.io'


### PR DESCRIPTION
Build using make prod-k8 to leave the placeholders in the compiled files. Then the new start-k8.sh handles replacing the env vars into those files before starting up the nginx instance.

Will allow for the configmap to apply env vars to the running k8 pod to allow for url configuration per env at a runtime config.
